### PR TITLE
Allow to pass in an identifier as well.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cstr"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Xidorn Quan <me@upsuper.org>"]
 description = "Macro for building static CStr reference"
 repository = "https://github.com/upsuper/cstr"
@@ -12,5 +12,5 @@ readme = "README.md"
 travis-ci = { repository = "upsuper/cstr", branch = "master" }
 
 [dependencies]
-cstr-macros = {path = "./macros", version = "0.1.4"}
+cstr-macros = {path = "./macros", version = "0.1.5"}
 procedural-masquerade = "0.1"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/upsuper/cstr.svg?branch=master)](https://travis-ci.org/upsuper/cstr)
 [![Docs](https://docs.rs/cstr/badge.svg)](https://docs.rs/cstr)
 
-A macro for getting `&'static CStr` from literal.
+A macro for getting `&'static CStr` from literal or identifier.
 
 This macro checks whether the given literal is valid for `CStr`
 at compile time, and returns a static reference of `CStr`.
@@ -23,6 +23,8 @@ use std::ffi::CStr;
 
 fn main() {
     let test = cstr!("hello");
+    assert_eq!(test, CStr::from_bytes_with_nul(b"hello\0").unwrap());
+    let test = cstr!(hello);
     assert_eq!(test, CStr::from_bytes_with_nul(b"hello\0").unwrap());
 }
 ```

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cstr-macros"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Xidorn Quan <me@upsuper.org>"]
 description = "Procedural macros for cstr"
 repository = "https://github.com/upsuper/cstr"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -17,12 +17,19 @@ define_proc_macros! {
     }
 }
 
+fn input_to_string(input: &str) -> String {
+    if let Ok(s) = syn::parse_str::<syn::LitStr>(input) {
+        return s.value().to_string();
+    }
+    if let Ok(i) = syn::parse_str::<syn::Ident>(input) {
+        return i.to_string();
+    }
+    panic!("expected a string literal or an identifier, got {}", input)
+}
+
 fn build_bytes(input: &str) -> String {
-    let s = match syn::parse_str::<syn::LitStr>(input) {
-        Ok(s) => s,
-        _ => panic!("expected a string literal, got {}", input)
-    };
-    let cstr = match CString::new(s.value()) {
+    let s = input_to_string(input);
+    let cstr = match CString::new(s.as_bytes()) {
         Ok(s) => s,
         _ => panic!("literal must not contain NUL byte")
     };
@@ -54,6 +61,7 @@ mod tests {
         assert_eq!(build_bytes!("\t\n\r\"\\'"), result!(b"\t\n\r\"\\\'\0"));
         assert_eq!(build_bytes!("\x01\x02 \x7f"), result!(b"\x01\x02 \x7f\0"));
         assert_eq!(build_bytes!("你好"), result!(b"\xe4\xbd\xa0\xe5\xa5\xbd\0"));
+        assert_eq!(build_bytes!(foobar), result!(b"foobar\0"));
     }
 
     #[test]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -19,7 +19,7 @@ define_proc_macros! {
 
 fn input_to_string(input: &str) -> String {
     if let Ok(s) = syn::parse_str::<syn::LitStr>(input) {
-        return s.value().to_string();
+        return s.value();
     }
     if let Ok(i) = syn::parse_str::<syn::Ident>(input) {
         return i.to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! A macro for getting `&'static CStr` from literal.
+//! A macro for getting `&'static CStr` from literal or identifier.
 //!
 //! This macro checks whether the given literal is valid for `CStr`
 //! at compile time, and returns a static reference of `CStr`.
@@ -18,6 +18,8 @@
 //!
 //! # fn main() {
 //! let test = cstr!("hello");
+//! assert_eq!(test, CStr::from_bytes_with_nul(b"hello\0").unwrap());
+//! let test = cstr!(hello);
 //! assert_eq!(test, CStr::from_bytes_with_nul(b"hello\0").unwrap());
 //! # }
 //! ```


### PR DESCRIPTION
`stringify!` is not expanded by the time you get to proc macros, so it's hard to
turn an ident into a macro, yet it is still useful. @bholley had a use-case for
this for gleam (I assume profiling related?).