### PR TITLE
Update error message for Rust 1.54+

### DIFF
--- a/tests/compile_fail/empty.stderr
+++ b/tests/compile_fail/empty.stderr
@@ -4,4 +4,4 @@ error: unexpected end of input, expected one of: byte string literal, string lit
 4 |     let _foo = cstr!();
   |                ^^^^^^^
   |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `cstr` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
The Rust error "this error originates in a macro" was modified in https://github.com/rust-lang/rust/commit/0dd9f118d973bb077c6ff0e2a57421ca2eecb81c (in Rust 1.54.0), so cstr's tests are failing with Rust 1.54+.
