### PR TITLE
Support no_std (Rust 1.64 and later)

### DIFF
--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -1,0 +1,27 @@
+use crate::parse::parse_input;
+pub(super) use proc_macro::TokenStream as RawTokenStream;
+use proc_macro2::{Literal, Span, TokenStream};
+use quote::{quote, quote_spanned};
+use std::ffi::CString;
+
+pub(crate) struct Error(pub(crate) Span, pub(crate) &'static str);
+
+pub(super) fn cstr(input: RawTokenStream) -> RawTokenStream {
+    let tokens = match build_byte_str(input.into()) {
+        Ok(s) => quote!(unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(#s) }),
+        Err(Error(span, msg)) => quote_spanned!(span => compile_error!(#msg)),
+    };
+    tokens.into()
+}
+
+fn build_byte_str(input: TokenStream) -> Result<Literal, Error> {
+    let (bytes, span) = parse_input(input)?;
+    match CString::new(bytes) {
+        Ok(s) => {
+            let mut lit = Literal::byte_string(s.as_bytes_with_nul());
+            lit.set_span(span);
+            Ok(lit)
+        }
+        Err(_) => Err(Error(span, "nul byte found in the literal")),
+    }
+}

--- a/src/implementation.rs
+++ b/src/implementation.rs
@@ -8,7 +8,7 @@ pub(crate) struct Error(pub(crate) Span, pub(crate) &'static str);
 
 pub(super) fn cstr(input: RawTokenStream) -> RawTokenStream {
     let tokens = match build_byte_str(input.into()) {
-        Ok(s) => quote!(unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(#s) }),
+        Ok(s) => quote!(unsafe { ::core::ffi::CStr::from_bytes_with_nul_unchecked(#s) }),
         Err(Error(span, msg)) => quote_spanned!(span => compile_error!(#msg)),
     };
     tokens.into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,15 @@
 // While this isn't necessary when using Cargo >= 1.42, omitting it actually requires path-less
 // `--extern proc_macro` to be passed to `rustc` when building this crate. Some tools may not do
 // this correctly. So it's added as a precaution.
+#[cfg(proc_macro)]
 extern crate proc_macro;
 
+#[cfg(proc_macro)]
 mod parse;
+#[cfg(proc_macro)]
 mod implementation;
 
+#[cfg(proc_macro)]
 #[proc_macro]
 pub fn cstr(input: implementation::RawTokenStream) -> implementation::RawTokenStream {
     implementation::cstr(input)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,33 +24,10 @@
 // this correctly. So it's added as a precaution.
 extern crate proc_macro;
 
-use crate::parse::parse_input;
-use proc_macro::TokenStream as RawTokenStream;
-use proc_macro2::{Literal, Span, TokenStream};
-use quote::{quote, quote_spanned};
-use std::ffi::CString;
-
 mod parse;
-
-struct Error(Span, &'static str);
+mod implementation;
 
 #[proc_macro]
-pub fn cstr(input: RawTokenStream) -> RawTokenStream {
-    let tokens = match build_byte_str(input.into()) {
-        Ok(s) => quote!(unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(#s) }),
-        Err(Error(span, msg)) => quote_spanned!(span => compile_error!(#msg)),
-    };
-    tokens.into()
-}
-
-fn build_byte_str(input: TokenStream) -> Result<Literal, Error> {
-    let (bytes, span) = parse_input(input)?;
-    match CString::new(bytes) {
-        Ok(s) => {
-            let mut lit = Literal::byte_string(s.as_bytes_with_nul());
-            lit.set_span(span);
-            Ok(lit)
-        }
-        Err(_) => Err(Error(span, "nul byte found in the literal")),
-    }
+pub fn cstr(input: implementation::RawTokenStream) -> implementation::RawTokenStream {
+    implementation::cstr(input)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //! let test = cstr!(hello);
 //! assert_eq!(test, CStr::from_bytes_with_nul(b"hello\0").unwrap());
 //! ```
+#![cfg_attr(not(proc_macro), no_std)]
 
 // While this isn't necessary when using Cargo >= 1.42, omitting it actually requires path-less
 // `--extern proc_macro` to be passed to `rustc` when building this crate. Some tools may not do

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::implementation::Error;
 use proc_macro2::{Delimiter, Ident, Literal, Span, TokenStream, TokenTree};
 use std::char;
 


### PR DESCRIPTION
Closes: https://github.com/upsuper/cstr/issues/12 (see previous discussion there).

This requires Rust 1.64 (or the version in which cstr_core gets stabilized if things do get reverted; it's already in current nightlies). I don't have any automated tests to offer for whether the result truly works without std -- I've tested it in my applications, but given how tests rely on std, it's not easy to prove no_std operation without building for a target that has no std library. Given that there are few dependencies and no `extern crate std` code, I don't think that this necessarily needs extra testing.