### PR TITLE
Support no_std (Rust 1.64 and later) (Take 2)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # This should follow 1.64 as it progresses throgh beta to stable
-          toolchain: nightly
+          toolchain: stable
           target: thumbv7em-none-eabi
           override: true
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,26 @@ jobs:
           command: check
           args: --tests
 
+  build_no_std:
+    name: Build on no_std
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          # This should follow 1.64 as it progresses throgh beta to stable
+          toolchain: nightly
+          target: thumbv7em-none-eabi
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: >-
+            --verbose
+            --target thumbv7em-none-eabi
+            --manifest-path tests/test_no_std/Cargo.toml
+
   test:
     name: Test Suite
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 keywords = ["macro", "cstr"]
 readme = "README.md"
 edition = "2018"
+rust-version = "1.64"
 
 [lib]
 proc-macro = true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A macro for getting `&'static CStr` from literal or identifier.
 This macro checks whether the given literal is valid for `CStr`
 at compile time, and returns a static reference of `CStr`.
 
-This macro can be used to to initialize constants on Rust 1.59 and above.
+This macro can be used to to initialize constants on Rust 1.64 and above.
 
 ## Example
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ struct Error(Span, &'static str);
 #[proc_macro]
 pub fn cstr(input: RawTokenStream) -> RawTokenStream {
     let tokens = match build_byte_str(input.into()) {
-        Ok(s) => quote!(unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(#s) }),
+        Ok(s) => quote!(unsafe { ::core::ffi::CStr::from_bytes_with_nul_unchecked(#s) }),
         Err(Error(span, msg)) => quote_spanned!(span => compile_error!(#msg)),
     };
     tokens.into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! This macro checks whether the given literal is valid for `CStr`
 //! at compile time, and returns a static reference of `CStr`.
 //!
-//! This macro can be used to to initialize constants on Rust 1.59 and above.
+//! This macro can be used to to initialize constants on Rust 1.64 and above.
 //!
 //! ## Example
 //!

--- a/tests/test_no_std/.gitignore
+++ b/tests/test_no_std/.gitignore
@@ -1,0 +1,2 @@
+/target/
+Cargo.lock

--- a/tests/test_no_std/Cargo.toml
+++ b/tests/test_no_std/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test_no_std"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+
+publish = false
+
+[dependencies]
+cstr.path = "../../"

--- a/tests/test_no_std/src/lib.rs
+++ b/tests/test_no_std/src/lib.rs
@@ -1,0 +1,15 @@
+//! Verifies that cstr! can be used on no_std systems.
+//!
+//! To ensure that `std` is not sneaked in through a dependency (even though this crate has none at
+//! runtime), this should best be built on a target that has no `std` because it has no operating
+//! system, eg. thumbv7em-none-eabi.
+//!
+//! Note that building the [`cstr`] crate alone is insufficient, as it does not run throuogh any
+//! `cstr!()` code generation and thus not trip over std-isms in the generated code.
+#![no_std]
+
+use core::ffi::CStr;
+
+pub fn can_use_cstr_macro() -> &'static CStr {
+    cstr::cstr!("Hello World!")
+}


### PR DESCRIPTION
Closes: https://github.com/upsuper/cstr/issues/12 (see previous discussion there)
Replaces: https://github.com/upsuper/cstr/pull/13

Based on the discussion in #13 I've revisited some assumptions, and removed parts of the PR that were based on my wrong understanding of proc-macro crates.

The patches are now in a sequence that, by running CI on them, shows that the test for no-std behavior alone fails, whereas the second patch fixes it.

As before, this breaks support for Rust versions < 1.64, so CI will report all but the "Build on no_std" tests as failing -- so this only makes sense to merge at the point when 1.64 is stable (at which the "nightly" in the test can be switched over).